### PR TITLE
Compile and release for macOS via continous integration

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -21,9 +21,9 @@ jobs:
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-latest] #, windows-latest]
+        os: [macos-latest] #, ubuntu-latest, windows-latest]
         build_type: [Release]
-        c_compiler: [gcc] #, clang, cl]
+        c_compiler: [clang] #, gcc, cl]
         # include:
         #   - os: windows-latest
         #     c_compiler: cl

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -47,12 +47,16 @@ jobs:
       id: checkout
       uses: actions/checkout@v4
 
-    - name: Install libmapper
+    - name: Install Homebrew (macOS only)
+      id: install-homebrew
+      if: contains(matrix.os,'macos')
+      run: |
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    - name: Install libmapper (macOS only)
       id: install-libmapper
-      uses: jaxxstorm/action-install-gh-release@v1.10.0
-      with: # Grab a specific tag
-        repo: libmapper/libmapper
-        tag: v2.5.1
+      if: contains(matrix.os,'macos')
+      run: |
+        sudo brew install libmapper
 
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -47,6 +47,13 @@ jobs:
       id: checkout
       uses: actions/checkout@v4
 
+    - name: Install libmapper
+      id: install-libmapper
+      uses: jaxxstorm/action-install-gh-release@v1.10.0
+      with: # Grab a specific tag
+        repo: libmapper/libmapper
+        tag: v2.5.1
+
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
       id: strings

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -4,6 +4,8 @@ name: CMake on multiple platforms
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -51,6 +51,8 @@ jobs:
     - name: Checkout
       id: checkout
       uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
 
     - name: Install Homebrew (macOS only)
       id: install-homebrew

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -24,7 +24,10 @@ jobs:
         os: [macos-latest] #, ubuntu-latest, windows-latest]
         build_type: [Release]
         c_compiler: [clang] #, gcc, cl]
-        # include:
+        include:
+          - os: macos-latest
+            c_compiler: clang
+            cpp_compiler: clang
         #   - os: windows-latest
         #     c_compiler: cl
         #     cpp_compiler: cl

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -74,6 +74,7 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         -DSUPERNOVA=ON
         -S ${{ github.workspace }}
 

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -79,7 +79,6 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         -DSUPERNOVA=ON
         -S ${{ github.workspace }}
 

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -56,7 +56,7 @@ jobs:
       id: install-libmapper
       if: contains(matrix.os,'macos')
       run: |
-        sudo brew install libmapper
+        brew install libmapper
 
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -43,7 +43,9 @@ jobs:
             c_compiler: cl
 
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout
+      id: checkout
+      uses: actions/checkout@v4
 
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
@@ -55,6 +57,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      id: configure
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
@@ -65,9 +68,11 @@ jobs:
 
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      id: build
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
 
     - name: Test
+      id: test
       working-directory: ${{ steps.strings.outputs.build-output-dir }}
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: [macos-latest] #, ubuntu-latest, windows-latest]
         build_type: [Release]
-        c_compiler: [clang] #, gcc, cl]
+        c_compiler: [cc] #, clang, gcc, cl]
         include:
           - os: macos-latest
             c_compiler: cc

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -87,7 +87,10 @@ jobs:
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       id: build
-      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+      run: > 
+        cmake --build ${{ steps.strings.outputs.build-output-dir }} 
+        --config ${{ matrix.build_type }}
+        --target install
 
     - name: Test
       id: test

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -28,8 +28,8 @@ jobs:
         c_compiler: [clang] #, gcc, cl]
         include:
           - os: macos-latest
-            c_compiler: clang
-            cpp_compiler: clang
+            c_compiler: cc
+            cpp_compiler: c++
         #   - os: windows-latest
         #     c_compiler: cl
         #     cpp_compiler: cl

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -95,3 +95,15 @@ jobs:
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest --build-config ${{ matrix.build_type }}
+
+    - name: Shorten SHA
+      id: shorten-sha
+      run: |
+        echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+    - name: Upload artifact
+      id: upload-artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: MapperUGen-${{ env.SHA_SHORT }}-${{matrix.os}}-${{matrix.build_type}}-${{matrix.c_compiler}}
+        path: build/MapperUGen/

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -21,26 +21,26 @@ jobs:
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest] #, windows-latest]
         build_type: [Release]
-        c_compiler: [gcc, clang, cl]
-        include:
-          - os: windows-latest
-            c_compiler: cl
-            cpp_compiler: cl
-          - os: ubuntu-latest
-            c_compiler: gcc
-            cpp_compiler: g++
-          - os: ubuntu-latest
-            c_compiler: clang
-            cpp_compiler: clang++
-        exclude:
-          - os: windows-latest
-            c_compiler: gcc
-          - os: windows-latest
-            c_compiler: clang
-          - os: ubuntu-latest
-            c_compiler: cl
+        c_compiler: [gcc] #, clang, cl]
+        # include:
+        #   - os: windows-latest
+        #     c_compiler: cl
+        #     cpp_compiler: cl
+        #   - os: ubuntu-latest
+        #     c_compiler: gcc
+        #     cpp_compiler: g++
+        #   - os: ubuntu-latest
+        #     c_compiler: clang
+        #     cpp_compiler: clang++
+        # exclude:
+        #   - os: windows-latest
+        #     c_compiler: gcc
+        #   - os: windows-latest
+        #     c_compiler: clang
+        #   - os: ubuntu-latest
+        #     c_compiler: cl
 
     steps:
     - name: Checkout

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -55,11 +55,11 @@ jobs:
       if: contains(matrix.os,'macos')
       run: |
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-    - name: Install libmapper (macOS only)
-      id: install-libmapper
+    - name: Install dependencies (macOS only)
+      id: install-dependencies
       if: contains(matrix.os,'macos')
       run: |
-        brew install libmapper
+        brew install boost libmapper
 
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "supercollider"]
 	path = supercollider
-	url = https://github.com/supercollider/supercollider.git
+	url = https://github.com/supercollider/supercollider/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(FILENAME "Mapper.cpp") #specify the .cpp file here
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 4.3)
 get_filename_component(PROJECT ${FILENAME} NAME_WE) #automatically sets project name from the filename
 # set(PROJECT "my_name") #alternatively set project name manually
 message(STATUS "Project name is ${PROJECT}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,16 @@ if(MINGW)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mstackrealign")
 endif()
 
+if(APPLE)
+    if(DEFINED ENV{HOMEBREW_PREFIX})
+        message(STATUS "Homebrew detected with prefix " $ENV{HOMEBREW_PREFIX})
+        include_directories(SYSTEM $ENV{HOMEBREW_PREFIX}/include)
+        link_directories(SYSTEM $ENV{HOMEBREW_PREFIX}/lib)
+    else()
+        message(STATUS "Homebrew not detected")
+    endif()
+endif()
+
 add_library(${PROJECT} MODULE ${FILENAME})
 target_link_libraries(${PROJECT} ${MAPPER_LIB} ${Boost_libraries})
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,30 @@
 # MapperUGen
+
 A SuperCollider UGen for using libmapper
 
-## Installation
+## Prerequisites
+
+### Install libmapper
+
+Please follow the [libmapper](https://github.com/libmapper/libmapper) documentation, unless your configuration is covered by specific cases below:
+
+#### macOS with homebrew
+
+- Install [Homebrew](https://brew.sh/)
+- Install dependencies
+    ```
+    brew install boost libmapper
+    ```
+
+## Installation from releases
+
 * Install [SuperCollider](https://supercollider.github.io/)
-* Build and install [libmapper](https://github.com/libmapper/libmapper)
 * Unzip MapperUGen.zip from [releases](https://github.com/IDMIL/MapperUGen/releases) into SuperCollider extensions folder (Platform.userExtensionDir)
 
-## Compile from source
-* Build and install [libmapper](https://github.com/libmapper/libmapper)
+## Compilation from source
+
 ### GNU/Linux
+
 ```
 git clone https://github.com/IDMIL/MapperUGen.git
 cd MapperUGen
@@ -16,7 +32,9 @@ mkdir build && cd build
 cmake -DSUPERNOVA=ON ..
 cmake --build . --target install
 ```
+
 ### macOS/Windows
+
 ```
 git clone --recursive https://github.com/IDMIL/MapperUGen.git
 cd MapperUGen

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ A SuperCollider UGen for using libmapper
 ## Installation
 * Install [SuperCollider](https://supercollider.github.io/)
 * Build and install [libmapper](https://github.com/libmapper/libmapper)
-* Unzip MapperUGen.zip from [releases](https://github.com/mathiasbredholt/MapperUGen/releases) into SuperCollider extensions folder (Platform.userExtensionDir)
+* Unzip MapperUGen.zip from [releases](https://github.com/IDMIL/MapperUGen/releases) into SuperCollider extensions folder (Platform.userExtensionDir)
 
 ## Compile from source
 * Build and install [libmapper](https://github.com/libmapper/libmapper)
 ### GNU/Linux
 ```
-git clone https://github.com/mathiasbredholt/MapperUGen.git
+git clone https://github.com/IDMIL/MapperUGen.git
 cd MapperUGen
 mkdir build && cd build
 cmake -DSUPERNOVA=ON ..
@@ -18,7 +18,7 @@ cmake --build . --target install
 ```
 ### macOS/Windows
 ```
-git clone --recursive https://github.com/mathiasbredholt/MapperUGen.git
+git clone --recursive https://github.com/IDMIL/MapperUGen.git
 cd MapperUGen
 mkdir build && cd build
 cmake -DSUPERNOVA=ON ..

--- a/README.md
+++ b/README.md
@@ -23,22 +23,10 @@ Please follow the [libmapper](https://github.com/libmapper/libmapper) documentat
 
 ## Compilation from source
 
-### GNU/Linux
-
-```
-git clone https://github.com/IDMIL/MapperUGen.git
-cd MapperUGen
-mkdir build && cd build
-cmake -DSUPERNOVA=ON ..
-cmake --build . --target install
-```
-
-### macOS/Windows
-
 ```
 git clone --recursive https://github.com/IDMIL/MapperUGen.git
 cd MapperUGen
-mkdir build && cd build
-cmake -DSUPERNOVA=ON ..
-cmake --build . --target install
+mkdir -p build
+cmake -B ./build -DSUPERNOVA=ON
+cmake --build build --target install
 ```


### PR DESCRIPTION
Closes: #1

## Changelog

- [x] Add continous integration with `.github/workflows/cmake-multi-platform.yml`
- [x] Update supercollider submodule to https://github.com/supercollider/supercollider/tree/Version-3.14.1
- [x] Share build artifacts
- [ ] Lock dependency versions for install via homebrew (libmapper and boost and supercollider)

### Deferred to subsequent pull requests

- Fix shortened SHA https://github.com/IDMIL/MapperUGen/pull/3#issuecomment-4285993485
- Import upstream changes from libmapper fork https://github.com/libmapper/MapperUGen/pulls?q=is%3Apr+is%3Aclosed 
- Compile and release for more platforms